### PR TITLE
Overhaul bootstrap build system and flashing workflow

### DIFF
--- a/adilos/.editorconfig
+++ b/adilos/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+indent_size = 4

--- a/adilos/.gitattributes
+++ b/adilos/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/adilos/Makefile
+++ b/adilos/Makefile
@@ -1,40 +1,52 @@
-SHELL := /bin/bash
-ROOT := $(CURDIR)
-OUT_DIR := $(ROOT)/out
-ROOTFS_IMG := $(OUT_DIR)/rootfs/adilos-rootfs.img
-HALIUM_BOOT_IMG := $(OUT_DIR)/boot/halium-boot.img
+# Makefile (AdilOS)
+# Outputs: out/boot, out/rootfs
 
-.PHONY: all rootfs halium-boot flash push-rootfs clean ensure-out
+REPO_ROOT := $(abspath .)
+OUT_BOOT  := $(REPO_ROOT)/out/boot
+OUT_ROOTFS:= $(REPO_ROOT)/out/rootfs
+
+INITRAMFS := $(OUT_BOOT)/initramfs.cpio.gz
+HALIUM_BOOT_IMG := $(OUT_BOOT)/halium-boot.img
+ROOTFS_IMG := $(OUT_ROOTFS)/adilos-rootfs.img
+
+PMOS_BUILD := $(REPO_ROOT)/rootfs/pmos/build_rootfs.sh
+MKINIT     := $(REPO_ROOT)/boot/halium-initramfs/mkinitramfs.sh
+MKBOOT     := $(REPO_ROOT)/boot/device/or_any/make_halium_boot.sh
+
+.PHONY: all rootfs initramfs halium-boot dirs clean help
 
 all: rootfs halium-boot
 
-ensure-out:
-@mkdir -p $(OUT_DIR)/rootfs $(OUT_DIR)/boot
+dirs:
+	@mkdir -p "$(OUT_BOOT)" "$(OUT_ROOTFS)"
+	@mkdir -p "$(REPO_ROOT)/boot"
+	@[ -L "$(REPO_ROOT)/boot/out" ] || ln -snf "$(OUT_BOOT)" "$(REPO_ROOT)/boot/out"
 
-rootfs: ensure-out
-ROOTFS_OUT=$(ROOTFS_IMG) $(ROOT)/rootfs/pmos/build_rootfs.sh
+initramfs: $(INITRAMFS)
 
-halium-boot: ensure-out
-HALIUM_BOOT_OUT=$(HALIUM_BOOT_IMG) $(ROOT)/boot/device/oriole/make_halium_boot.sh
+$(INITRAMFS): | dirs
+	@echo "[+] Building initramfs..."
+	@bash "$(MKINIT)"
+	@[ -f "$(INITRAMFS)" ] || ln -sf "$(REPO_ROOT)/boot/out/initramfs.cpio.gz" "$(INITRAMFS)"
+	@ls -lh "$(INITRAMFS)"
 
-push-rootfs:
-@if [ ! -f "$(ROOTFS_IMG)" ]; then \
-echo "Rootfs image missing, run make rootfs first"; \
-exit 1; \
-fi
-$(ROOT)/scripts/adb_wait.sh shell 'mkdir -p /data/adilos && chmod 700 /data/adilos'
-adb push $(ROOTFS_IMG) /data/adilos/adilos-rootfs.img
+rootfs: $(ROOTFS_IMG)
 
-flash: halium-boot rootfs
-@if [ ! -f "$(HALIUM_BOOT_IMG)" ]; then \
-echo "halium-boot image missing, run make halium-boot"; \
-exit 1; \
-fi
-fastboot devices
-fastboot flash boot $(HALIUM_BOOT_IMG)
-fastboot reboot
-$(MAKE) push-rootfs
+$(ROOTFS_IMG): | dirs
+	@echo "[+] Building rootfs image..."
+	@bash "$(PMOS_BUILD)" "$(ROOTFS_IMG)"
+	@ls -lh "$(ROOTFS_IMG)"
+
+halium-boot: $(HALIUM_BOOT_IMG)
+
+$(HALIUM_BOOT_IMG): initramfs | dirs
+	@echo "[+] Building halium-boot image..."
+	@bash "$(MKBOOT)" --initramfs "$(INITRAMFS)" --out "$(HALIUM_BOOT_IMG)"
+	@ls -lh "$(HALIUM_BOOT_IMG)"
 
 clean:
-rm -rf $(OUT_DIR)
+	@echo "[+] Cleaning outputs..."
+	@rm -rf "$(OUT_BOOT)" "$(OUT_ROOTFS)"
 
+help:
+	@echo "Targets: all (default), initramfs, rootfs, halium-boot, clean"

--- a/adilos/README.md
+++ b/adilos/README.md
@@ -1,24 +1,69 @@
-# AdilOS Ignition MVP
+# AdilOS — Bootstrap Repo (Universal Build + Flash)
 
-AdilOS ("FairOS") is a privacy-first mobile operating system targeting the Google Pixel 6 (oriole). This repository contains the tooling, configuration, and reference applications required to build a Halium-style boot image, generate an Alpine/postmarketOS-based root filesystem, and assemble a minimal first-boot experience with local AI capabilities.
+This repo builds a Halium-style initramfs + halium-boot.img and a minimal ext4 rootfs so you can boot AdilOS to a shell on real Android hardware. It also includes a universal flasher that works across A/B and fastbootd devices.
 
-## Highlights
+## Pre-flight (Ubuntu/Debian)
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  adb fastboot android-bootimg pmbootstrap python3 python3-pip cmake ninja-build build-essential \
+  curl git unzip dos2unix \
+  qt6-base-dev qt6-base-dev-tools qt6-webengine-dev || true
 
-- **Security & Privacy:** Apache-2.0 licensing, no telemetry or ads, Ecosia as the default search engine, and a one-tap child-safe DNS and content filter.
-- **Device Target:** Google Pixel 6 (oriole) via a Halium boot flow that mounts a looped rootfs image from userdata.
-- **User Experience:** Phosh-based compositor with AdilShell UX, AdilBrowser, FairStore, and demo AdilNotes app. Waydroid integration is optional and disabled by default.
-- **Local AI:** Offline speech recognition (Whisper), text generation (LLaMA/llama.cpp), and text-to-speech (Piper) exposed via lightweight HTTP services and DBus shims.
+# If pmbootstrap unavailable/too old:
+mkdir -p "$HOME/src" && cd "$HOME/src"
+git clone --depth=1 https://gitlab.postmarketos.org/postmarketOS/pmbootstrap.git
+mkdir -p "$HOME/.local/bin"
+ln -snf "$HOME/src/pmbootstrap/pmbootstrap.py" "$HOME/.local/bin/pmbootstrap"
+export PATH="$HOME/.local/bin:$PATH"
+pmbootstrap --version
 
-## Repository Layout
-
+# Optional udev rule (no sudo for adb/fastboot)
+echo 'SUBSYSTEM=="usb", ATTR{idVendor}=="18d1", MODE="0666", GROUP="plugdev"' | \
+  sudo tee /etc/udev/rules.d/51-android.rules >/dev/null
+sudo udevadm control --reload-rules && sudo udevadm trigger
 ```
-adilos/
-  boot/              # halium initramfs and device-specific packaging
-  rootfs/            # pmbootstrap helpers and overlay files
-  packages/          # UI, AI, store, and helper applications
-  services/          # systemd units for core services and toggles
-  tools/             # flashing utilities and model download helpers
-  docs/              # quickstart and troubleshooting references
+
+## Build
+
+```bash
+make
+# outputs:
+#  out/boot/initramfs.cpio.gz
+#  out/rootfs/adilos-rootfs.img
+#  out/boot/halium-boot.img
 ```
 
-Refer to [`docs/QUICKSTART.md`](docs/QUICKSTART.md) for build and flashing instructions, and [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md) for debugging tips.
+### Building halium-boot.img with a stock boot
+
+Place a stock boot.img and repack with our initramfs automatically via:
+
+```bash
+HALIUM_STOCK_BOOT=/path/to/stock_boot.img bash boot/device/or_any/make_halium_boot.sh \
+  --initramfs out/boot/initramfs.cpio.gz \
+  --out out/boot/halium-boot.img \
+  --stock-boot "$HALIUM_STOCK_BOOT"
+```
+
+## Flash (universal)
+
+```bash
+chmod +x scripts/flash_adilos.sh
+
+# Full pipeline (build → push → flash):
+bash -euxo pipefail scripts/flash_adilos.sh
+
+# If images already built:
+bash -euxo pipefail scripts/flash_adilos.sh --no-build
+
+# Temporary boot (won’t persist):
+bash -euxo pipefail scripts/flash_adilos.sh --no-build --temp-boot
+
+# Partition/slot overrides:
+bash -euxo pipefail scripts/flash_adilos.sh --partition=init_boot --slot=a
+```
+
+## Notes
+- This rootfs is a stub for smoke tests; it boots and drops to a shell. Swap it with a real postmarketOS/Alpine userspace next.
+- PEP 668: do not install Python tools globally with pip. Use apt or git link for pmbootstrap.
+- Makefile uses LF endings and requires TABs for recipes.

--- a/adilos/boot/device/or_any/make_halium_boot.sh
+++ b/adilos/boot/device/or_any/make_halium_boot.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INITRAMFS=""
+OUT_IMG=""
+KERNEL_IMG="${KERNEL_IMG:-}"
+STOCK_BOOT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --initramfs) INITRAMFS="$2"; shift 2 ;;
+    --out) OUT_IMG="$2"; shift 2 ;;
+    --stock-boot) STOCK_BOOT="$2"; shift 2 ;;
+    *) echo "[!] Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$INITRAMFS" || -z "$OUT_IMG" ]]; then
+  echo "Usage: $0 --initramfs path.cpio.gz --out halium-boot.img [--stock-boot stock_boot.img]" >&2
+  exit 1
+fi
+
+if [[ ! -f "$INITRAMFS" ]]; then
+  echo "[!] Missing initramfs: $INITRAMFS" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT_IMG")"
+
+command -v mkbootimg >/dev/null 2>&1 || { echo "[!] mkbootimg not found (install android-bootimg)" >&2; exit 1; }
+if [[ -n "$STOCK_BOOT" ]]; then
+  command -v unpackbootimg >/dev/null 2>&1 || { echo "[!] unpackbootimg not found (install android-bootimg)" >&2; exit 1; }
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+BASE_ARGS=()
+CMDLINE=""
+PAGESIZE=""
+BOARD=""
+HEADERV=""
+
+if [[ -n "$STOCK_BOOT" ]]; then
+  if [[ ! -f "$STOCK_BOOT" ]]; then
+    echo "[!] stock boot not found: $STOCK_BOOT" >&2
+    exit 1
+  fi
+  echo "[i] Unpacking stock boot: $STOCK_BOOT"
+  unpackbootimg -i "$STOCK_BOOT" -o "$TMP" >/dev/null 2>&1 || true
+
+  if [[ -z "$KERNEL_IMG" ]]; then
+    KERNEL_IMG="$(ls "$TMP"/*-kernel 2>/dev/null | head -n1 || true)"
+  fi
+
+  [[ -f "$TMP"/*-cmdline ]] && CMDLINE="$(cat "$TMP"/*-cmdline || true)"
+  [[ -f "$TMP"/*-pagesize ]] && PAGESIZE="$(cat "$TMP"/*-pagesize || true)"
+  [[ -f "$TMP"/*-board ]] && BOARD="$(cat "$TMP"/*-board || true)"
+  [[ -f "$TMP"/*-header_version ]] && HEADERV="$(cat "$TMP"/*-header_version || true)"
+
+  [[ -n "$CMDLINE"  ]] && BASE_ARGS+=(--cmdline "$CMDLINE")
+  [[ -n "$PAGESIZE" ]] && BASE_ARGS+=(--pagesize "$PAGESIZE")
+  [[ -n "$BOARD"    ]] && BASE_ARGS+=(--board "$BOARD")
+  [[ -n "$HEADERV"  ]] && BASE_ARGS+=(--header_version "$HEADERV")
+fi
+
+if [[ -z "$KERNEL_IMG" || ! -f "$KERNEL_IMG" ]]; then
+  echo "[!] Set KERNEL_IMG or pass --stock-boot" >&2
+  exit 1
+fi
+
+echo "[+] Building halium-boot: $OUT_IMG"
+mkbootimg --kernel "$KERNEL_IMG" \
+          --ramdisk "$INITRAMFS" \
+          "${BASE_ARGS[@]}" \
+          --output "$OUT_IMG"
+
+echo "[+] halium-boot ready: $OUT_IMG"

--- a/adilos/boot/halium-initramfs/init
+++ b/adilos/boot/halium-initramfs/init
@@ -1,42 +1,33 @@
 #!/bin/sh
-set -eu
-PATH=/sbin:/bin:/usr/sbin:/usr/bin
-export PATH
-. /init.functions
+set -eux
 
-log "AdilOS initramfs starting"
+mount -t devtmpfs devtmpfs /dev
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
 
-mount_core_fs || emergency_shell "Failed to mount core filesystems"
-
-USERDATA=$(find_userdata)
-[ -n "$USERDATA" ] || emergency_shell "Could not locate userdata partition"
-
-log "Mounting userdata from $USERDATA"
-mkdir -p /data
-if ! mount -t ext4 -o rw,noatime "$USERDATA" /data; then
-  emergency_shell "Failed to mount userdata"
-fi
-
-mkdir -p /data/adilos
-ROOTFS_IMG=/data/adilos/adilos-rootfs.img
-if [ ! -f "$ROOTFS_IMG" ]; then
-  emergency_shell "Rootfs image missing at $ROOTFS_IMG"
-fi
-
-log "Setting up loop device for rootfs"
-mkdir -p /newroot
-LOOPDEV=$(losetup -f --show "$ROOTFS_IMG") || emergency_shell "losetup failed"
-
-if ! mount -t ext4 -o rw,noatime "$LOOPDEV" /newroot; then
-  emergency_shell "Unable to mount loop rootfs"
-fi
-
-for dir in dev proc sys run; do
-  mkdir -p /newroot/"$dir"
-  mount --bind /"$dir" /newroot/"$dir"
+echo "AdilOS initramfs: locating userdata..."
+USERDATA=""
+for P in /dev/block/by-name/userdata /dev/block/platform/*/by-name/userdata /dev/block/*; do
+  if [ -e "$P" ]; then USERDATA="$P"; break; fi
 done
 
-echo "" > /newroot/etc/.initramfs
+[ -n "$USERDATA" ] || { echo "No userdata found"; exec sh; }
 
-log "Switching to real root"
-exec switch_root /newroot /sbin/init "$@"
+mkdir -p /data
+mount -t ext4 -o rw,noatime "$USERDATA" /data || exec sh
+
+mkdir -p /data/adilos
+if [ ! -f /data/adilos/adilos-rootfs.img ]; then
+  echo "Missing /data/adilos/adilos-rootfs.img; dropping to shell."
+  exec sh
+fi
+
+mkdir -p /newroot
+LOOPDEV="$(losetup -f --show /data/adilos/adilos-rootfs.img)"
+mount -t ext4 -o rw,noatime "$LOOPDEV" /newroot || exec sh
+
+mount --bind /dev /newroot/dev
+mount --bind /proc /newroot/proc
+mount --bind /sys /newroot/sys
+
+exec switch_root /newroot /sbin/init

--- a/adilos/boot/halium-initramfs/mkinitramfs.sh
+++ b/adilos/boot/halium-initramfs/mkinitramfs.sh
@@ -1,22 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT=$(realpath "$(dirname "$0")")
-OUT=${OUT:-$ROOT/../out/initramfs.cpio.gz}
-WORKDIR=$(mktemp -d)
-trap 'rm -rf "$WORKDIR"' EXIT
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OUT_DIR="${REPO_ROOT}/out/boot"
+OUT="${OUT_DIR}/initramfs.cpio.gz"
 
-mkdir -p "$WORKDIR"/{bin,sbin,dev,proc,sys,run,etc}
-cp "$ROOT/init" "$WORKDIR/"
-cp "$ROOT/init.functions" "$WORKDIR/"
-chmod +x "$WORKDIR/init"
+mkdir -p "${OUT_DIR}"
 
+WORKDIR="$(mktemp -d)"
+trap 'rm -rf "${WORKDIR}"' EXIT
+
+mkdir -p "${WORKDIR}"/{bin,sbin,etc,proc,sys,dev,newroot,data}
+cp "${SCRIPT_DIR}/init" "${WORKDIR}/init"
+chmod +x "${WORKDIR}/init"
+
+# BusyBox (optional, improves shell)
 if command -v busybox >/dev/null 2>&1; then
-  cp "$(command -v busybox)" "$WORKDIR/bin/busybox"
-else
-  echo "Using prebuilt busybox is not supported yet." >&2
-  exit 1
+  cp "$(command -v busybox)" "${WORKDIR}/bin/busybox"
+  cat > "${WORKDIR}/bin/sh" <<'SH'
+#!/bin/sh
+exec /bin/busybox sh "$@"
+SH
+  chmod +x "${WORKDIR}/bin/sh"
 fi
 
-( cd "$WORKDIR" && find . | cpio -H newc -o ) | gzip -c > "$OUT"
-echo "Created initramfs at $OUT"
+# Create the archive
+( cd "${WORKDIR}" && find . -print0 | cpio --null -ov --format=newc | gzip -9 ) > "${OUT}"
+
+echo "Created initramfs at ${OUT}"

--- a/adilos/docs/QUICKSTART.md
+++ b/adilos/docs/QUICKSTART.md
@@ -1,101 +1,30 @@
-# AdilOS Ignition Quickstart
+# AdilOS Quickstart
 
-This guide walks through building the AdilOS MVP artifacts and flashing them to an unlocked Google Pixel 6 (`oriole`).
-
-## Host Requirements
-
-- Linux workstation (Debian/Ubuntu/Arch tested)
-- `pmbootstrap` (see [postmarketOS docs](https://wiki.postmarketos.org/wiki/Pmbootstrap))
-- `fastboot` and `adb`
-- `python3`, `pip`, `cmake`, `ninja`, `gcc`, `qt6` development packages
-- Network access to fetch Alpine/APK indexes
-
-```bash
-sudo apt install android-sdk-platform-tools python3-pip cmake ninja-build qt6-base-dev qt6-declarative-dev qt6-webengine-dev
-pip install --user pmbootstrap
-```
-
-## Repository Layout
-
-- `boot/halium-initramfs/`: BusyBox initramfs that mounts the looped rootfs image
-- `boot/device/oriole/`: scripts for composing `halium-boot.img`
-- `rootfs/pmos/`: wrappers around `pmbootstrap` to build an Alpine/postmarketOS rootfs
-- `packages/`: AdilOS UI, browser, store, AI, and helper tools
-- `tools/`: flashing utility and model fetch helper
-
-## Build Steps
-
-1. **Create the initramfs**
-
-   ```bash
-   cd adilos/boot/halium-initramfs
-   ./mkinitramfs.sh
-   ```
-
-2. **Build the rootfs image**
-
-   ```bash
-   cd adilos
-   make rootfs
-   ```
-
-   This invokes `pmbootstrap` using the configuration in `rootfs/pmos/pmos_init.conf`, applies the overlay, and exports `out/rootfs/adilos-rootfs.img`.
-
-3. **Assemble `halium-boot.img`**
-
-   Provide device-specific kernel, `dtb`, and `dtbo` artifacts in `boot/device/oriole/`. Then run:
-
-   ```bash
-   make halium-boot
-   ```
-
-   The output `out/boot/halium-boot.img` uses the initramfs generated above.
-
-## Flashing to Pixel 6
-
-1. Unlock the bootloader if not already unlocked:
+1. Enable OEM unlocking + USB debugging on device.
+2. Unlock bootloader (wipes data):
 
    ```bash
    adb reboot bootloader
    fastboot flashing unlock
    ```
 
-2. Flash the boot image and push the rootfs:
+3. Install host deps:
 
    ```bash
-   cd adilos
-   make flash
+   sudo apt-get update
+   sudo apt-get install -y adb fastboot android-bootimg pmbootstrap python3 python3-pip cmake ninja-build build-essential curl git unzip dos2unix qt6-base-dev qt6-base-dev-tools qt6-webengine-dev || true
    ```
 
-   or manually:
+4. Build artifacts:
 
    ```bash
-   fastboot flash boot out/boot/halium-boot.img
-   fastboot reboot
-   adb shell 'mkdir -p /data/adilos && chmod 700 /data/adilos'
-   adb push out/rootfs/adilos-rootfs.img /data/adilos/adilos-rootfs.img
-   adb reboot
+   make
    ```
 
-3. Optional: tail logs during first boot using the flashing helper:
+5. Flash:
 
    ```bash
-   python3 tools/adilflasher/adilflasher.py
+   bash -euxo pipefail scripts/flash_adilos.sh --no-build
    ```
 
-## First Boot Smoke Tests
-
-After reboot, perform these checks:
-
-1. Screen lights up with Phosh and AdilShell overlays.
-2. Touch input works; open the terminal to verify.
-3. Connect to Wi-Fi via `nmcli dev wifi connect "SSID" password "PASS"`.
-4. Launch **AdilBrowser** and confirm Ecosia search.
-5. Open **FairStore** and view the seeded AdilNotes listing.
-6. Trigger the AI Palette in AdilShell; if models are downloaded using `tools/fetch_models.sh`, expect a local response.
-
-## Next Steps
-
-- Populate `/data/adilos/models` with GGUF, Whisper, and Piper models.
-- Add more Flatpak manifests to `packages/fairstore/manifests/`.
-- Extend Waydroid support by fleshing out the helper scripts.
+If it fails to flash, the script will try fastbootd and A/B slots. You can also pass `--temp-boot` for a non-persistent test.

--- a/adilos/docs/TROUBLESHOOTING.md
+++ b/adilos/docs/TROUBLESHOOTING.md
@@ -1,37 +1,12 @@
-# Troubleshooting AdilOS Ignition
+# Troubleshooting
 
-## Boot loops or black screen
+- **Makefile: `*** missing separator`** → tabs/CRLF issue. Run:
 
-- **Check userdata mount:** Drop into the initramfs shell by holding volume up during boot. Run `ls /dev/block/by-name` to confirm `userdata` exists. Mount manually with `mount -t ext4 /dev/block/by-name/userdata /data`.
-- **Missing rootfs image:** Ensure `/data/adilos/adilos-rootfs.img` exists. Use `adb push` from recovery or re-run `make flash`.
-- **switch_root failure:** Inspect `/dev/kmsg` logs. Confirm the initramfs `losetup` succeeded and the rootfs image contains `/sbin/init`.
+  ```bash
+  bash tools/fix_line_endings.sh
+  ```
 
-## initramfs shell access
-
-- Connect via USB, run `adb shell` once the fallback BusyBox shell is active.
-- Logs are streamed to `/dev/kmsg`; use `dmesg` for review.
-
-## Waydroid not starting
-
-- Verify binderfs is mounted: `mount | grep binder`. If missing, run `/usr/bin/enable_waydroid.sh` manually.
-- Confirm `waydroid-container.service` is enabled (`systemctl status waydroid-container.service`).
-
-## Network issues
-
-- Use `nmcli device status` to confirm the Wi-Fi device is managed.
-- Delete stale connections with `nmcli connection delete <name>` and retry.
-
-## AI services
-
-- Services log to `journalctl -u adilai-llm.service` etc.
-- Populate `/data/adilos/models` with the required model files and adjust service configuration accordingly.
-
-## Child Mode
-
-- Toggle via `systemctl start childmode.service` to enable the DNS filter. Ensure `dnscrypt-proxy` is installed.
-- To disable, run `systemctl stop childmode.service` and remove `/etc/adilos/childmode.enabled`.
-
-## Updating the rootfs overlay
-
-- Edit files under `rootfs/pmos/overlay/` and rebuild the image with `make rootfs`.
-- Use `scripts/loop_image.sh` to mount the generated image locally for inspection.
+- **`mkbootimg`/`unpackbootimg` missing** → `sudo apt-get install -y android-bootimg`.
+- **pmbootstrap “externally managed environment”** → never pip install. Use apt or git link per README.
+- **Initramfs can’t find userdata** → device path differs; adjust `/dev/block/...` probe in `boot/halium-initramfs/init`.
+- **Stuck in initramfs shell (“Missing rootfs image”)** → ensure `/data/adilos/adilos-rootfs.img` was pushed (flasher does this; or `adb push` manually).

--- a/adilos/rootfs/pmos/build_rootfs.sh
+++ b/adilos/rootfs/pmos/build_rootfs.sh
@@ -1,37 +1,37 @@
 #!/usr/bin/env bash
 set -euo pipefail
+OUT_IMG="${1:?Usage: build_rootfs.sh /path/to/adilos-rootfs.img}"
 
-ROOT=$(realpath "$(dirname "$0")/../..")
-WORKDIR=${PMOS_WORKDIR:-$ROOT/.pmbootstrap}
-OUT_IMAGE=${ROOTFS_OUT:-$ROOT/out/rootfs/adilos-rootfs.img}
-OVERLAY_DIR=$(realpath "$(dirname "$0")/overlay")
-PACKAGES_LIST=$(realpath "$(dirname "$0")/packages.list")
-PMOS_INIT_CONF=$(realpath "$(dirname "$0")/pmos_init.conf")
+SIZE_MB="${ADILOS_ROOTFS_SIZE_MB:-2048}"
+TMPDIR="$(mktemp -d)"
+cleanup(){ sudo umount "$TMPDIR" 2>/dev/null || true; rmdir "$TMPDIR" 2>/dev/null || true; }
+trap cleanup EXIT
 
-if ! command -v pmbootstrap >/dev/null 2>&1; then
-  echo "pmbootstrap is required; install from https://wiki.postmarketos.org/" >&2
-  exit 1
+echo "[i] Creating ext4 rootfs image (${SIZE_MB}MB) at $OUT_IMG"
+mkdir -p "$(dirname "$OUT_IMG")"
+dd if=/dev/zero of="$OUT_IMG" bs=1M count="$SIZE_MB" status=none
+mkfs.ext4 -F "$OUT_IMG" >/dev/null
+sudo mount -o loop "$OUT_IMG" "$TMPDIR"
+
+sudo mkdir -p "$TMPDIR"/{proc,sys,dev,run,bin,sbin,etc,usr/bin,usr/sbin,root,var,tmp,home}
+sudo chmod 1777 "$TMPDIR/tmp"
+
+cat <<'INIT' | sudo tee "$TMPDIR/sbin/init" >/dev/null
+#!/bin/sh
+mount -t proc proc /proc
+mount -t sysfs sysfs /sys
+mount -t devtmpfs devtmpfs /dev 2>/dev/null || true
+echo "AdilOS demo rootfs: dropping to shell. Replace with real userspace."
+exec /bin/sh
+INIT
+sudo chmod +x "$TMPDIR/sbin/init"
+
+if command -v busybox >/dev/null 2>&1; then
+  sudo cp "$(command -v busybox)" "$TMPDIR/bin/busybox" || true
+  printf '%s\n' '#!/bin/sh' 'exec /bin/busybox sh "$@"' | sudo tee "$TMPDIR/bin/sh" >/dev/null
+  sudo chmod +x "$TMPDIR/bin/sh"
 fi
 
-mkdir -p "$WORKDIR"
-
-pmbootstrap -w "$WORKDIR" init --config "$PMOS_INIT_CONF" --aports-branch edge --force
-
-while IFS= read -r pkg; do
-  [[ -z "$pkg" || "$pkg" =~ ^# ]] && continue
-  pmbootstrap -w "$WORKDIR" pkg install "$pkg"
-done < "$PACKAGES_LIST"
-
-pmbootstrap -w "$WORKDIR" install --overlay "$OVERLAY_DIR" --hostname adilos --wipe
-
-IMAGE_SIZE_MB=${ROOTFS_SIZE_MB:-6144}
-"$ROOT/scripts/mkrootfs_ext4.sh" "$OUT_IMAGE" "$IMAGE_SIZE_MB"
-
-ROOTFS_MOUNT=$(mktemp -d)
-trap 'sudo umount "$ROOTFS_MOUNT" || true; rmdir "$ROOTFS_MOUNT"' EXIT
-sudo mount "$OUT_IMAGE" "$ROOTFS_MOUNT"
-sudo rsync -a "$WORKDIR/chroot_native/home/pmos/rootfs/" "$ROOTFS_MOUNT/"
-sudo umount "$ROOTFS_MOUNT"
-rmdir "$ROOTFS_MOUNT"
-
-echo "Rootfs image created at $OUT_IMAGE"
+sudo umount "$TMPDIR"
+sync
+echo "[+] Rootfs demo image created: $OUT_IMG"

--- a/adilos/scripts/flash_adilos.sh
+++ b/adilos/scripts/flash_adilos.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+trap 'echo "[!] Error at ${BASH_SOURCE[0]}:${LINENO} (exit $?)" >&2' ERR
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_BOOT="${REPO_ROOT}/out/boot"
+OUT_ROOTFS="${REPO_ROOT}/out/rootfs"
+
+HALIUM_INITRAMFS_SCRIPT="${REPO_ROOT}/boot/halium-initramfs/mkinitramfs.sh"
+ROOTFS_IMG="${OUT_ROOTFS}/adilos-rootfs.img"
+HALIUM_BOOT_IMG="${OUT_BOOT}/halium-boot.img"
+ADILFLasher="${REPO_ROOT}/tools/adilflasher/adilflasher.py"
+
+DO_BUILD=1
+DO_PUSH=1
+DO_FLASH=1
+TEMP_BOOT=0
+PARTITION="auto"
+SLOT="auto"
+
+usage() {
+  cat <<'EOF'
+Usage: $(basename "$0") [options]
+  --no-build           Skip building (images must exist)
+  --build-only         Build only (no push/flash)
+  --flash-only         Flash only (skip build/push)
+  --push-only          Push rootfs only (skip build/flash)
+  --temp-boot          Use 'fastboot boot <img>' (no flashing)
+  --partition=NAME     boot|init_boot|recovery|auto (default: auto)
+  --slot=MODE          auto|a|b|both (default: auto)
+  -h, --help           Show help
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) DO_BUILD=0 ;;
+    --build-only) DO_BUILD=1; DO_PUSH=0; DO_FLASH=0 ;;
+    --flash-only) DO_BUILD=0; DO_PUSH=0; DO_FLASH=1 ;;
+    --push-only) DO_BUILD=0; DO_PUSH=1; DO_FLASH=0 ;;
+    --temp-boot) TEMP_BOOT=1 ;;
+    --partition=*) PARTITION="${arg#*=}" ;;
+    --slot=*) SLOT="${arg#*=}" ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[!] Unknown option: $arg"; usage; exit 2 ;;
+  esac
+done
+
+ensure_dirs() {
+  mkdir -p "${OUT_BOOT}" "${OUT_ROOTFS}"
+  mkdir -p "${REPO_ROOT}/boot"
+  if [[ ! -L "${REPO_ROOT}/boot/out" ]]; then
+    rm -rf "${REPO_ROOT}/boot/out" 2>/dev/null || true
+    ln -snf "${OUT_BOOT}" "${REPO_ROOT}/boot/out"
+  fi
+}
+
+install_host_deps() {
+  if command -v apt-get >/dev/null 2>&1; then
+    local sudo_cmd=""
+    if [[ "${EUID}" -ne 0 ]]; then
+      if command -v sudo >/dev/null 2>&1; then
+        sudo_cmd="sudo"
+      else
+        echo "[!] apt-based distribution detected but sudo/root privileges unavailable." >&2
+        echo "    Re-run with sudo or install dependencies manually." >&2
+        exit 1
+      fi
+    fi
+    ${sudo_cmd} apt-get update
+    BASE_PKGS=(adb fastboot android-bootimg python3 python3-pip cmake ninja-build build-essential curl git unzip dos2unix)
+    if apt-cache show qt6-base-dev >/dev/null 2>&1; then
+      QT_PKGS=(qt6-base-dev qt6-base-dev-tools)
+      apt-cache show qt6-webengine-dev >/dev/null 2>&1 && QT_PKGS+=(qt6-webengine-dev)
+    else
+      QT_PKGS=(qtbase5-dev qtbase5-dev-tools)
+      apt-cache show qtwebengine5-dev >/dev/null 2>&1 && QT_PKGS+=(qtwebengine5-dev)
+    fi
+    ${sudo_cmd} apt-get install -y "${BASE_PKGS[@]}" "${QT_PKGS[@]}" || {
+      echo "[!] apt install failed; install deps manually and rerun." >&2; exit 1;
+    }
+  else
+    echo "[i] Non-apt distro: ensure adb, fastboot, android-bootimg, toolchain, Qt, curl, git, unzip."
+  fi
+}
+
+ensure_pmbootstrap() {
+  if command -v pmbootstrap >/dev/null 2>&1; then
+    echo "[+] pmbootstrap: $(pmbootstrap --version || true)"; return
+  fi
+  if command -v apt-get >/dev/null 2>&1; then
+    local sudo_cmd=""
+    if [[ "${EUID}" -ne 0 ]]; then
+      if command -v sudo >/dev/null 2>&1; then
+        sudo_cmd="sudo"
+      else
+        sudo_cmd=""
+      fi
+    fi
+    ${sudo_cmd} apt-get update || true
+    ${sudo_cmd} apt-get install -y pmbootstrap python3 git openssl || true
+    command -v pmbootstrap >/dev/null 2>&1 && { echo "[+] pmbootstrap installed (apt)"; return; }
+  fi
+  echo "[i] Installing pmbootstrap from git..."
+  mkdir -p "${HOME}/src"
+  if [[ ! -d "${HOME}/src/pmbootstrap" ]]; then
+    git clone --depth=1 https://gitlab.postmarketos.org/postmarketOS/pmbootstrap.git "${HOME}/src/pmbootstrap"
+  fi
+  mkdir -p "${HOME}/.local/bin"
+  ln -snf "${HOME}/src/pmbootstrap/pmbootstrap.py" "${HOME}/.local/bin/pmbootstrap"
+  export PATH="${HOME}/.local/bin:${PATH}"
+  command -v pmbootstrap >/dev/null 2>&1 || { echo "[!] pmbootstrap not found on PATH"; exit 1; }
+  echo "[+] pmbootstrap installed (git): $(pmbootstrap --version || true)"
+}
+
+wait_for_adb() {
+  echo "[+] Waiting for ADB device..."
+  for _ in {1..30}; do
+    if adb get-state >/dev/null 2>&1; then return 0; fi
+    sleep 1
+  done
+  echo "[i] No ADB device detected; will push rootfs after flash if possible."
+  return 1
+}
+
+wait_for_fastboot() {
+  echo "[+] Waiting for fastboot device..."
+  for _ in {1..30}; do
+    if fastboot devices | grep -qE '\\sfastboot$'; then return 0; fi
+    sleep 1
+  done
+  echo "[!] No device in fastboot. Enter bootloader (Power+VolDown) and retry." >&2
+  exit 1
+}
+
+get_slot() {
+  fastboot getvar current-slot 2>&1 | tr -d '\r' | awk -F ': ' '/current-slot/ {print $2}'
+}
+
+reboot_fastbootd() {
+  echo "[i] Rebooting into fastbootd..."
+  fastboot reboot fastboot || true
+  sleep 2
+  wait_for_fastboot
+}
+
+flash_to_partition() {
+  local part="$1" img="$2" target="$part"
+  local cur slot="${SLOT}"
+  cur="$(get_slot || true)"
+  if [[ -n "$cur" ]]; then
+    case "$slot" in
+      auto) target="${part}_${cur}" ;;
+      a|b)  target="${part}_${slot}" ;;
+      both)
+        echo "[i] Flashing both slots for ${part}..."
+        fastboot flash "${part}_a" "${img}" || true
+        fastboot flash "${part}_b" "${img}" || true
+        return 0
+        ;;
+      *) target="${part}_${cur}" ;;
+    esac
+  fi
+  echo "[+] fastboot flash ${target} ${img}"
+  fastboot flash "${target}" "${img}"
+}
+
+push_rootfs_via_adb() {
+  [[ -f "${ROOTFS_IMG}" ]] || { echo "[!] Missing ${ROOTFS_IMG}"; exit 1; }
+  if wait_for_adb; then
+    adb shell 'mkdir -p /data/adilos && chmod 700 /data/adilos' || true
+    adb push "${ROOTFS_IMG}" /data/adilos/adilos-rootfs.img
+    echo "[+] Rootfs push complete."
+    return 0
+  fi
+  return 1
+}
+
+build_artifacts() {
+  echo "[+] Building Halium initramfs..."
+  bash "${HALIUM_INITRAMFS_SCRIPT}"
+
+  echo "[+] Building AdilOS root filesystem..."
+  make -C "${REPO_ROOT}" rootfs
+
+  echo "[+] Building halium-boot image..."
+  make -C "${REPO_ROOT}" halium-boot
+
+  [[ -f "${HALIUM_BOOT_IMG}" ]] || { echo "[!] Missing ${HALIUM_BOOT_IMG}"; exit 1; }
+  [[ -f "${ROOTFS_IMG}"     ]] || { echo "[!] Missing ${ROOTFS_IMG}"; exit 1; }
+}
+
+flash_boot_any() {
+  local img="${HALIUM_BOOT_IMG}"
+  [[ -f "${img}" ]] || { echo "[!] Missing boot image: ${img}"; exit 1; }
+
+  wait_for_fastboot
+
+  if [[ "${TEMP_BOOT}" -eq 1 ]]; then
+    echo "[+] Temporary boot: fastboot boot ${img}"
+    fastboot boot "${img}"
+    return 0
+  fi
+
+  local try_parts=()
+  case "${PARTITION}" in
+    auto) try_parts=(boot init_boot) ;;
+    boot) try_parts=(boot) ;;
+    init_boot) try_parts=(init_boot) ;;
+    recovery) try_parts=(recovery) ;;
+    *) try_parts=(boot init_boot) ;;
+  esac
+
+  for p in "${try_parts[@]}"; do
+    if flash_to_partition "${p}" "${img}"; then
+      echo "[+] Flashed ${p} successfully."
+      fastboot reboot
+      return 0
+    fi
+  done
+
+  reboot_fastbootd
+  for p in "${try_parts[@]}"; do
+    if flash_to_partition "${p}" "${img}"; then
+      echo "[+] Flashed ${p} (fastbootd) successfully."
+      fastboot reboot
+      return 0
+    fi
+  done
+
+  echo "[!] Could not flash boot/init_boot on this device." >&2
+  exit 1
+}
+
+run_tail_helper() {
+  if [[ -f "${ADILFLasher}" ]]; then
+    read -rp "[?] Launch adilflasher log tail helper after reboot? [y/N] " answer
+    [[ "${answer}" =~ ^[Yy]$ ]] && python3 "${ADILFLasher}" || true
+  fi
+}
+
+main() {
+  [[ -f "${REPO_ROOT}/Makefile" ]] || { echo "[!] Not in repo root"; exit 1; }
+
+  ensure_dirs
+  install_host_deps
+  ensure_pmbootstrap
+
+  if [[ "${DO_BUILD}" -eq 1 ]]; then
+    build_artifacts
+  else
+    [[ -f "${HALIUM_BOOT_IMG}" ]] || { echo "[!] Missing ${HALIUM_BOOT_IMG}"; exit 1; }
+    [[ -f "${ROOTFS_IMG}"     ]] || { echo "[!] Missing ${ROOTFS_IMG}"; exit 1; }
+  fi
+
+  if [[ "${DO_PUSH}" -eq 1 ]]; then
+    push_rootfs_via_adb || echo "[i] Will try pushing rootfs after flashing if ADB appears."
+  fi
+
+  if [[ "${DO_FLASH}" -eq 1 ]]; then
+    if adb get-state >/dev/null 2>&1; then adb reboot bootloader || true; fi
+    flash_boot_any
+  fi
+
+  if [[ "${DO_PUSH}" -eq 1 ]]; then
+    push_rootfs_via_adb || echo "[i] Skipped post-flash rootfs push (no ADB)."
+  fi
+
+  run_tail_helper
+  echo "[+] All done. If you used --temp-boot, flashing is required for persistence."
+}
+main "$@"

--- a/adilos/tools/fix_line_endings.sh
+++ b/adilos/tools/fix_line_endings.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+command -v dos2unix >/dev/null 2>&1 || { echo "[i] dos2unix not found, using sed fallback"; }
+fix() {
+  local f="$1"
+  if command -v dos2unix >/dev/null 2>&1; then dos2unix "$f" >/dev/null 2>&1 || true; fi
+  sed -i 's/\r$//' "$f"
+  # strip BOM if present
+  sed -i '1s/^\xEF\xBB\xBF//' "$f"
+}
+fix Makefile
+echo "[+] Normalized line endings for Makefile"


### PR DESCRIPTION
## Summary
- rebuild the top-level Makefile and halium/rootfs helpers to emit canonical out/boot and out/rootfs artifacts with a boot/out symlink
- add a universal mkbootimg wrapper, minimal initramfs/init scripts, and a stub rootfs builder that boots to a shell
- replace the flashing helper with a universal fastboot/adb workflow, add newline guard tools, and refresh the README/quickstart/troubleshooting docs

## Testing
- not run (infrastructure/scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68e425445cf08320ad477f101c9da6d5